### PR TITLE
Fix wrong rotation on non zero starting joints

### DIFF
--- a/Assets/Rokoko/Art/Meshes/Newton/Rokoko_Newton.FBX.meta
+++ b/Assets/Rokoko/Art/Meshes/Newton/Rokoko_Newton.FBX.meta
@@ -433,7 +433,7 @@ ModelImporter:
     legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
     blendShapeNormalImportMode: 1
     normalSmoothingSource: 0
-  importAnimation: 1
+  importAnimation: 0
   copyAvatar: 0
   humanDescription:
     serializedVersion: 2

--- a/Assets/Rokoko/Art/Meshes/NewtonFace/Rokoko_Newtonface.FBX.meta
+++ b/Assets/Rokoko/Art/Meshes/NewtonFace/Rokoko_Newtonface.FBX.meta
@@ -106,7 +106,7 @@ ModelImporter:
     legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
     blendShapeNormalImportMode: 1
     normalSmoothingSource: 0
-  importAnimation: 1
+  importAnimation: 0
   copyAvatar: 0
   humanDescription:
     serializedVersion: 2

--- a/Assets/Rokoko/Scripts/Mono/Inputs/Actor.cs
+++ b/Assets/Rokoko/Scripts/Mono/Inputs/Actor.cs
@@ -182,11 +182,11 @@ namespace Rokoko.Inputs
             {
                 if (positionSpace == Space.World || transform.parent == null)
                 {
-                    boneTransform.position = worldPosition;
+                    boneTransform.localPosition = worldPosition;
                 }
                 else
                 {
-                    boneTransform.localPosition = boneTransform.parent.InverseTransformVector(worldPosition);
+                    boneTransform.localPosition = worldPosition;
                 }
             }
 
@@ -222,7 +222,7 @@ namespace Rokoko.Inputs
                 if (humanoidBones[bone] != null)
                 {
                     // Subtract Root orientation from bone
-                    Quaternion boneTransform = Quaternion.Inverse(humanoidBones[HumanBodyBones.Hips].rotation) * humanoidBones[bone].rotation;
+                    Quaternion boneTransform = Quaternion.Inverse(humanoidBones[HumanBodyBones.Hips].parent.rotation) * humanoidBones[bone].rotation;
                     // Subtract from SmartSuit T Pose
                     rotation = Quaternion.Inverse(SmartsuitTPose[bone]) * boneTransform;
                 }


### PR DESCRIPTION
Fix wrong offsets on non zero rotation joints.
Fix position to local space.
Disable import animation on Newton.